### PR TITLE
Drop obsolete dependency on distribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ test_dependencies = [
 ]
 
 dependencies = [
-  'distribute           >= 0.6.24',
   'globre               >= 0.0.5',
   'six                  >= 1.4.1',
 ]


### PR DESCRIPTION
From https://pythonhosted.org/distribute/:

"""
Distribute is a deprecated fork of the Setuptools project.

Since the Setuptools 0.7 release, Setuptools and Distribute have merged and
Distribute is no longer being maintained. All ongoing effort should reference
the Setuptools project and the Setuptools documentation.
"""

Signed-off-by: Justin Lecher jlec@gentoo.org
